### PR TITLE
let cargo install elba command include +nightly

### DIFF
--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -19,7 +19,7 @@ Because elba is written in Rust, it is available as an installable crate from [c
 Once you have Rust installed, installing elba is pretty self-explanatory:
 
 ```sh
-$ cargo install elba
+$ cargo +nightly install elba
 $ elba # should work!
 ```
 


### PR DESCRIPTION
The `cargo` command to install elba currently does not have the `+nightly` flag. A careless reader of the installation guide, like myself, could miss the instruction to use a nightly version of Rust.

With this change the command specifies the dependency on nightly right where the action happens. I probably would still miss it ;-) but at least when copied, things can't go wrong.