### PR TITLE
Improve manifest

### DIFF
--- a/src/lib/cli/build.rs
+++ b/src/lib/cli/build.rs
@@ -8,7 +8,7 @@ use crossbeam::queue::MsQueue;
 use failure::ResultExt;
 use package::{
     lockfile::LockfileToml,
-    manifest::Manifest,
+    manifest::{Manifest, BinTarget},
     resolution::{DirectRes, IndexRes},
     PackageId, Spec, Summary,
 };
@@ -107,6 +107,7 @@ pub fn test(
         }
         let emp = targets.is_empty();
         for (ix, bt) in manifest.targets.test.iter().enumerate() {
+            let bt: BinTarget = bt.clone().into();
             if emp || targets.contains(&bt.name.as_str()) {
                 root.push(Target::Test(ix));
             }
@@ -123,16 +124,16 @@ pub fn test(
             Verbosity::Quiet,
         );
 
-        let root = root
+        let root: Vec<BinTarget> = root
             .0
             .into_iter()
             .filter_map(|t| {
                 if let Target::Test(ix) = t {
-                    Some(&manifest.targets.test[ix])
+                    Some(manifest.targets.test[ix].clone().into())
                 } else {
                     None
                 }
-            }).collect::<Vec<_>>();
+            }).collect();
 
         // Until pb.println gets added, we can't use progress bars
         // let pb = ProgressBar::new(root.len() as u64);
@@ -540,6 +541,7 @@ pub fn build(
     // We only build test targets if the user asks for them.
     if let Some(ts) = &targets.3 {
         for (ix, bt) in manifest.targets.test.iter().enumerate() {
+            let bt: BinTarget = bt.clone().into();
             let target_specified = ts.is_empty() || ts.contains(&bt.name.as_str());
             if target_specified {
                 root.push(Target::Test(ix));

--- a/src/lib/cli/new.rs
+++ b/src/lib/cli/new.rs
@@ -2,7 +2,7 @@ use failure::ResultExt;
 use inflector::Inflector;
 use package::Name;
 use std::{fs, path::PathBuf};
-use util::errors::Res;
+use util::{errors::Res, git};
 
 pub struct NewCtx {
     pub path: PathBuf,
@@ -28,6 +28,8 @@ pub fn new(ctx: NewCtx) -> Res<String> {
 }
 
 pub fn init(ctx: NewCtx) -> Res<String> {
+    git::init(&ctx.path)?;
+
     let name = &ctx.name;
     let author = if let Some((author, email)) = ctx.author {
         format!("{} <{}>", author, email)
@@ -40,7 +42,6 @@ pub fn init(ctx: NewCtx) -> Res<String> {
         format!(
             r#"[[targets.bin]]
 name = "{}"
-path = "src/"
 main = "Main"
 
 "#,
@@ -49,7 +50,6 @@ main = "Main"
     } else {
         format!(
             r#"[targets.lib]
-path = "src/"
 mods = [
     "{}"
 ]

--- a/src/lib/package/manifest.rs
+++ b/src/lib/package/manifest.rs
@@ -201,7 +201,7 @@ fn default_bin_subpath() -> SubPath {
 /// I know, code duplication sucks and is stupid, but what can ya do :v
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct TestTarget {
-    pub name: String,
+    pub name: Option<String>,
     #[serde(default = "default_test_subpath")]
     pub path: SubPath,
     pub main: String,
@@ -215,8 +215,13 @@ fn default_test_subpath() -> SubPath {
 
 impl From<TestTarget> for BinTarget {
     fn from(t: TestTarget) -> Self {
+        let default_name = format!("tests-{}", &t.main)
+            .trim_right_matches(".idr")
+            .replace("/", "_")
+            .replace(".", "_");
+
         BinTarget {
-            name: t.name,
+            name: t.name.unwrap_or(default_name),
             path: t.path,
             main: t.main,
             idris_opts: t.idris_opts,

--- a/src/lib/util/git.rs
+++ b/src/lib/util/git.rs
@@ -34,6 +34,11 @@ use std::{env, fs, path::Path};
 use url::Url;
 use util::errors::Res;
 
+pub fn init(path: &Path) -> Res<()> {
+    git2::Repository::init(path)?;
+    Ok(())
+}
+
 pub fn clone(url: &Url, into: &Path) -> Res<git2::Repository> {
     let git_config = git2::Config::open_default()?;
     with_fetch_options(&git_config, &url, &mut |opts| {


### PR DESCRIPTION
  - `new` subcommand now sets up a git repo.

  - Make `targets.test.name` default to "tests-TestName".

  - Remove `targets.lib.path` and `targets.bin.path` in `new` template.