### PR TITLE
Fix compilation error: Deserialize/Serialize defined multiple times

### DIFF
--- a/src/lib/package/mod.rs
+++ b/src/lib/package/mod.rs
@@ -9,7 +9,8 @@ use crate::{
 };
 use failure::{bail, format_err, Error};
 use semver::Version;
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::{Deserialize, Deserializer, Error as DeError};
+use serde::ser::{Serialize, Serializer};
 use serde_derive::{Deserialize, Serialize};
 use std::{
     fmt,
@@ -172,7 +173,7 @@ impl fmt::Display for Name {
 impl<'de> Deserialize<'de> for Name {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        FromStr::from_str(&s).map_err(de::Error::custom)
+        FromStr::from_str(&s).map_err(DeError::custom)
     }
 }
 
@@ -248,7 +249,7 @@ impl fmt::Display for PackageId {
 impl<'de> Deserialize<'de> for PackageId {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        FromStr::from_str(&s).map_err(de::Error::custom)
+        FromStr::from_str(&s).map_err(DeError::custom)
     }
 }
 
@@ -317,7 +318,7 @@ impl fmt::Display for Checksum {
 impl<'de> Deserialize<'de> for Checksum {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
-        FromStr::from_str(&s).map_err(de::Error::custom)
+        FromStr::from_str(&s).map_err(DeError::custom)
     }
 }
 


### PR DESCRIPTION
When compiling from source, build fails with the following errors:

```
error[E0252]: the name `Deserialize` is defined multiple times
  --> src/lib/package/mod.rs:13:20
   |
12 | use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
   |                 ----------- previous import of the macro `Deserialize` here
13 | use serde_derive::{Deserialize, Serialize};
   |                    ^^^^^^^^^^^--
   |                    |
   |                    `Deserialize` reimported here
   |                    help: remove unnecessary import
   |
   = note: `Deserialize` must be defined only once in the macro namespace of this module

error[E0252]: the name `Serialize` is defined multiple times
  --> src/lib/package/mod.rs:13:33
   |
12 | use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
   |                                            --------- previous import of the macro `Serialize` here
13 | use serde_derive::{Deserialize, Serialize};
   |                                 ^^^^^^^^^ `Serialize` reimported here
   |
   = note: `Serialize` must be defined only once in the macro namespace of this module
```

Other info
* `cargo 1.36.0-nightly (759b6161a 2019-05-06)`
* OS Ubuntu 18.04

It looks related to this https://github.com/serde-rs/serde/issues/1441.

**I am not familiar with Rust/cargo, please double check this fix.** It works for me, but I do not know if it is the best solution.
