### PR TITLE
Add elba.pub link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Status](https://travis-ci.com/elba/elba.svg?branch=master)](https://travis-ci.co
 [![Windows Build
 Status](https://ci.appveyor.com/api/projects/status/j2pk9krx63o1dpdv?svg=true)](https://ci.appveyor.com/project/dcao/elba)
 
-A modern and (hopefully!) fast package manager for
+[Elba](https://www.elba.pub/) is a a modern and (hopefully!) fast package manager for
 [Idris](https://www.idris-lang.org). Supplemental information and alternatives
 can be found at [this blog post](http://cao.st/posts/elba/).
 


### PR DESCRIPTION
I followed a reddit post linking to https://www.cao.st/posts/elba-3-pub/
If it weren't for this article, I wouldn't know the website address, it's not mentioned anywhere on here.